### PR TITLE
3346398: Drupal 10 compatibility fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "docs": "https://term-reference-fancytree.readthedocs.io/en/latest"
   },
   "require": {
-    "drupal/core": "^8.8 || ^9",
+    "drupal/core": "^9.2 || ^10",
     "drupal/jquery_ui": "~1.0",
-    "drupal/jquery_ui_effects": "~1.0"
+    "drupal/jquery_ui_effects": "~2.0"
   }
 }

--- a/js/tree.js
+++ b/js/tree.js
@@ -36,13 +36,14 @@
         let treeSettings = settings.term_reference_fancytree[key].tree || [];
         if (treeSettings instanceof Array) {
           for (let i = 0; i < treeSettings.length; i++) {
+            const id = treeSettings[i].id;
             // Initialise a new Fancytree with our settings.
-            $('#' + treeSettings[i].id).once('term-reference-fancytree').each(function () {
+           $(once('term-reference-fancytree', `#${id}`)).each(function () {
               new Drupal.TermReferenceFancyTree(treeSettings[i].id, treeSettings[i].name, treeSettings[i].source, treeSettings[i].select_children, treeSettings[i].selection_mode, treeSettings[i].select_parents);
 
               if (treeSettings[i].select_all) {
-                $('#' + treeSettings[i].id + ' .selectAll').click(function () {
-                  $.ui.fancytree.getTree('#' + treeSettings[i].id).selectAllWithLazyLoad();
+                $(`#${id} .selectAll`).click(function () {
+                  $.ui.fancytree.getTree(`#${id}`).selectAllWithLazyLoad();
                   return false;
                 });
               }

--- a/src/Element/TermReferenceFancytree.php
+++ b/src/Element/TermReferenceFancytree.php
@@ -176,12 +176,13 @@ class TermReferenceFancytree extends FormElement {
   public static function loadTerms($vocabulary, $parent = 0) {
     try {
       $query = \Drupal::entityQuery('taxonomy_term')
+        ->accessCheck()
         ->condition('vid', $vocabulary->id())
         ->condition('parent', $parent)
         ->sort('weight')
         ->sort('name');
 
-      $tids = $query->execute();
+      $tids = $query->accessCheck()->execute();
 
       $terms = TermReferenceFancytree::getTermStorage()
         ->loadMultiple($tids);

--- a/term_reference_fancytree.info.yml
+++ b/term_reference_fancytree.info.yml
@@ -1,7 +1,7 @@
 name: 'Term Reference Fancytree'
 type: module
 description: 'Provides a tree like widget for term reference fields using the Fancytree plugin.'
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^9.2 || ^10
 dependencies:
   - 'drupal:taxonomy'
   - 'jquery_ui_effects:jquery_ui_effects'

--- a/term_reference_fancytree.libraries.yml
+++ b/term_reference_fancytree.libraries.yml
@@ -12,8 +12,8 @@ fancytree:
     js/jquery.fancytree.min.js: {}
   dependencies:
     - core/jquery
-    - core/jquery.ui
-    - core/jquery.ui.widget
+    - jquery_ui/core
+    - jquery_ui/widget
     - jquery_ui_effects/core
     - jquery_ui_effects/blind
 
@@ -27,3 +27,4 @@ tree:
   dependencies:
     - term_reference_fancytree/fancytree
     - core/drupalSettings
+    - core/once


### PR DESCRIPTION
The current module version isn't able to use on Drupal 10 implementations.

Some Drupal community members opened the https://www.drupal.org/project/term_reference_fancytree/issues/3346398 issue, reporting this compatibility issue and brought some fixes. These code modifications were brought by these members.

Please, update this module to cover the new Drupal's version.